### PR TITLE
Update Tdarr_Plugin_SV6x_Smoove1FFMPEG_NVENC_H264.js

### DIFF
--- a/Community/Tdarr_Plugin_SV6x_Smoove1FFMPEG_NVENC_H264.js
+++ b/Community/Tdarr_Plugin_SV6x_Smoove1FFMPEG_NVENC_H264.js
@@ -68,6 +68,7 @@ const plugin = (file, librarySettings, inputs, otherArguments) => {
     reQueueAfter: true,
     // Leave as true. File will be re-qeued afterwards and pass through the plugin
     // filter again to make sure it meets conditions.
+    preset: '', // Initialize with an empty string
   };
 
   // Check that inputs.container has been configured, else dump out


### PR DESCRIPTION
Fixes issue with `undefined` being added to the ffmpeg args.
> ffmpeg.exe undefined -i

Affected other users too, see [discord discussion here](https://discord.com/channels/623392507828371476/623799920574595092/1118188978059878482).